### PR TITLE
Define merkle-proof relation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [v1.1.1] - 2026-01-12
+
+### Fixed
+
+- Updated **Relation types** section to explicitly define `merkle-proof`, resolving a 
+contradiction where the spec previously stated no new relation types were introduced.
+- Clarified in "Linking to a Proof" that the **Root Catalog** acts as the trust anchor and therefore does not require a proof link.
+
 ## [v1.1.0] - 2026-01-12
 
 ### Added
@@ -43,7 +51,8 @@ in the `merkle:object_hash` to ensure data integrity.
 
 - first release
 
-[Unreleased]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.1.0...main
+[Unreleased]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.1.1...main
+[v1.1.1]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.1.1...v1.1.0
 [v1.1.0]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.0.0...v1.1.0
 [v1.0.0]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.0.0-beta.2...v1.0.0
 [v1.0.0-beta.2]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.0.0-beta.1...v1.0.0-beta.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ in the `merkle:object_hash` to ensure data integrity.
 - first release
 
 [Unreleased]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.1.1...main
-[v1.1.1]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.1.1...v1.1.0
+[v1.1.1]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.0.0...v1.1.0
 [v1.0.0]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.0.0-beta.2...v1.0.0
 [v1.0.0-beta.2]: https://github.com/stacchain/merkle-tree-stac-extension/tree/v1.0.0-beta.1...v1.0.0-beta.2

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ dataset, implementations SHOULD provide a **Merkle Proof**
 (also known as an audit path or witness).
 
 ### Linking to a Proof
-STAC objects SHOULD provide a link to their proof using the 
-`merkle-proof` relation. This link may point to a static file 
-(e.g., on S3) or a dynamic API endpoint.
+STAC objects (Items, Collections, and Child Catalogs) SHOULD provide a link to their proof using the 
+`merkle-proof` relation. **Note:** The Root Catalog acts as the trust anchor and therefore 
+does not have a proof.
 
 ```json
 "links": [
@@ -318,8 +318,11 @@ To generate a proof for a specific child object (Target) within a tree:
 
 ## Relation types
 
-This extension does not introduce any new relation types. The standard STAC relation types should be used as applicable in the
-[Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object).
+This extension introduces one new relation type to be used in the [Link Object](https://github.com/radiantearth/stac-spec/blob/master/commons/links.md#link-object).
+
+| Relation Type | Description |
+| :--- | :--- |
+| `merkle-proof` | Points to a Merkle Inclusion Proof JSON file that enables verification of the object's integrity and membership in the entire hierarchy up to the Root Catalog. (Not applicable to the Root Catalog itself). |
 
 ## Contributing
 


### PR DESCRIPTION
https://github.com/stacchain/merkle-tree/issues/2

- Updated **Relation types** section to explicitly define `merkle-proof`, resolving a 
contradiction where the spec previously stated no new relation types were introduced.
- Clarified in "Linking to a Proof" that the **Root Catalog** acts as the trust anchor and therefore does not require a proof link.